### PR TITLE
Implement text shrink when card is full of content

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,3 +1,9 @@
 {
-  "cards": []
+  "cards": [
+    {
+      "id": 1718268513366,
+      "content": "Dokończyć zadanie z TODO listą",
+      "createdAt": "2024-06-13T08:48:33.366Z"
+    }
+  ]
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import { render } from '@testing-library/react'
 import App from './App'
 

--- a/src/components/AppLayout/AppLayout.tsx
+++ b/src/components/AppLayout/AppLayout.tsx
@@ -2,6 +2,6 @@ import { PropsWithChildren } from 'react'
 
 import styles from './AppLayout.module.css'
 
-export const AppLayout = (props: PropsWithChildren<{}>) => (
+export const AppLayout = (props: PropsWithChildren<object>) => (
   <div className={styles.layout}>{props.children}</div>
 )

--- a/src/components/Board/Board.tsx
+++ b/src/components/Board/Board.tsx
@@ -2,7 +2,7 @@ import { PropsWithChildren } from 'react'
 
 import styles from './Board.module.css'
 
-export const Board = (props: PropsWithChildren<{}>) => (
+export const Board = (props: PropsWithChildren<object>) => (
   <div data-cy={'board'} className={styles.board}>
     {props.children}
   </div>

--- a/src/components/Board/__tests__/integration/Board.container.test.tsx
+++ b/src/components/Board/__tests__/integration/Board.container.test.tsx
@@ -1,3 +1,30 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import BoardContainer from '../../Board.container';
+
 describe('BoardContainer integration tests', () => {
-  // TODO: Add unit tests
+  beforeEach(() => {
+    render(<BoardContainer />)
+    const addCardButton = screen.getByRole('button', { name: /Add new card/i });
+    fireEvent.click(addCardButton);
+  })
+
+  it('allows adding new cards', () => {
+    expect(screen.getByTestId('card')).toBeInTheDocument(); 
+  });
+
+  it('allows editing cards', () => {
+    const card = screen.getByTestId('card');
+    fireEvent.click(card);
+    expect(screen.getByTestId('card-edit-form')).toBeInTheDocument();
+  })
+
+  it('allows deleting cards', async () => {
+    const card = screen.getByTestId('card')
+    fireEvent.click(card)
+    fireEvent.keyDown(card, { key: 'backspace' })
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(card).not.toBeInTheDocument()
+  })
 })

--- a/src/components/Board/__tests__/unit/Board.test.tsx
+++ b/src/components/Board/__tests__/unit/Board.test.tsx
@@ -1,3 +1,11 @@
+import { render, screen } from "@testing-library/react"
+import { Board } from "../../Board"
+
 describe('Board component unit tests', () => {
-  // TODO: Add unit tests
+  it('renders children within Board component', () => {
+    const childrenContent = <p data-testid='board-text'>Test komponentu Board</p>
+    render(<Board>{childrenContent}</Board>)
+
+    expect(screen.getByTestId('board-text')).toBeInTheDocument()
+  })
 })

--- a/src/components/Card/Card.module.css
+++ b/src/components/Card/Card.module.css
@@ -28,3 +28,7 @@
   line-height: var(--line-height-17);
   font-size: var(--font-size-14);
 }
+
+.content {
+  overflow-wrap: break-word;
+}

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -1,3 +1,35 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Card } from './Card';
+
 describe('Card component unit tests', () => {
-  // TODO: Add unit tests
+  it('renders date correctly', async () => {
+    const mockCard = {
+      id: 1,
+      createdAt: '2024-06-14T09:00:00',
+      content: 'Example content',
+    };
+    const { getByTestId } = render(<Card {...mockCard} />);
+    expect(getByTestId('card-date')).toBeInTheDocument();
+  });
+
+  it('displays content correctly when not in edit mode', async () => {
+    const mockCard = {
+      id: 1,
+      createdAt: '2024-06-14T09:00:00',
+      content: 'Example content',
+    };
+    const { getByText } = render(<Card {...mockCard} />);
+    expect(getByText('Example content')).toBeInTheDocument();
+  });
+
+  it('triggers edit mode when clicked', async () => {
+    const mockCard = {
+      id: 1,
+      createdAt: '2024-06-14T09:00:00',
+      content: 'Example content',
+    };
+    const { getByText, getByTestId } = render(<Card {...mockCard} />);
+    fireEvent.click(getByText('Example content'));
+    expect(getByTestId('card-edit-form')).toBeInTheDocument();
+  });
 })

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -105,7 +105,7 @@ export const Card = (props: CardProps) => {
       onClick={handleSetEditingOn}
       ref={cardRef}
     >
-      <p ref={dateRef} className={styles.date}>
+      <p ref={dateRef} className={styles.date} data-testid='card-date'>
         {props.createdAt ? formatDate(props.createdAt) : 'Date'}
       </p>
       {!isEditing ? (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -42,7 +42,9 @@ export const Card = (props: CardProps) => {
         {props.createdAt ? formatDate(props.createdAt) : 'Date'}
       </p>
       {!isEditing ? (
-        <p>{props?.content || 'Click to start noting'}</p>
+        <p className={styles.content}>
+          {props?.content || 'Click to start noting'}
+        </p>
       ) : (
         <CardContentForm
           initialValues={props}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useRef, useState, useEffect } from 'react'
 
 import { CardContentForm } from './card-elements/CardContentForm'
 
@@ -16,6 +16,10 @@ interface CardProps extends CardModelData {
 export const Card = (props: CardProps) => {
   const ref = useRef(null)
   const [isEditing, setEditing] = useState(false)
+  const [fontSize, setFontSize] = useState(16)
+  const cardRef = useRef<HTMLDivElement>(null)
+  const dateRef = useRef<HTMLParagraphElement>(null)
+  const contentRef = useRef<HTMLParagraphElement>(null)
 
   const handleSetEditingOff = () => {
     setEditing(false)
@@ -27,9 +31,71 @@ export const Card = (props: CardProps) => {
     setEditing(true)
   }
 
+  const adjustFontSize = () => {
+    if (contentRef.current && cardRef.current) {
+      const contentTop = contentRef.current.getBoundingClientRect().top
+      const contentBottom = contentRef.current.getBoundingClientRect().bottom
+
+      const cardRect = cardRef.current.getBoundingClientRect().top
+      const dateRect = contentTop - cardRect
+
+      const availableSpace = cardRect - dateRect - 20
+
+      if (contentBottom - contentTop > availableSpace) {
+        setFontSize((prevFontSize) => Math.max(prevFontSize - 2, 4))
+      } else {
+        setFontSize((prevFontSize) => {
+          let newSize = prevFontSize
+
+          let adjusted = false;
+
+          while (newSize < 16) {
+            newSize += 2;
+            if (contentRef.current) {
+              contentRef.current.style.fontSize = `${newSize}px`;
+              const { top, bottom } = contentRef.current.getBoundingClientRect();
+              const newContentHeight = bottom - top;
+
+              if (newContentHeight > availableSpace) {
+                contentRef.current.style.fontSize = `${newSize - 2}px`;
+                adjusted = true;
+                newSize -= 2;
+                break;
+              }
+            } else {
+              break;
+            }
+          }
+
+          if (!adjusted) {
+            return newSize;
+          }
+
+          return prevFontSize
+        })
+      }
+    }
+  }
+
+  useEffect(() => {
+    let initialRender = true
+
+    if (initialRender) {
+      initialRender = false
+      return
+    }
+
+    adjustFontSize()
+  }, [])
+
+  useEffect(() => {
+    adjustFontSize()
+  }, [props.content])
+
   const handleSaveContent = (values: CardModelData) => {
     props.onUpdateCard && props.onUpdateCard(values)
     handleSetEditingOff()
+    adjustFontSize()
   }
 
   return (
@@ -37,12 +103,17 @@ export const Card = (props: CardProps) => {
       data-cy={`card-${props.id}`}
       className={styles.card}
       onClick={handleSetEditingOn}
+      ref={cardRef}
     >
-      <p className={styles.date}>
+      <p ref={dateRef} className={styles.date}>
         {props.createdAt ? formatDate(props.createdAt) : 'Date'}
       </p>
       {!isEditing ? (
-        <p className={styles.content}>
+        <p
+          ref={contentRef}
+          className={styles.content}
+          style={{ fontSize: `${fontSize}px` }}
+        >
           {props?.content || 'Click to start noting'}
         </p>
       ) : (

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -100,6 +100,7 @@ export const Card = (props: CardProps) => {
 
   return (
     <div
+      data-testid='card'
       data-cy={`card-${props.id}`}
       className={styles.card}
       onClick={handleSetEditingOn}

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -47,28 +47,28 @@ export const Card = (props: CardProps) => {
         setFontSize((prevFontSize) => {
           let newSize = prevFontSize
 
-          let adjusted = false;
+          let adjusted = false
 
           while (newSize < 16) {
-            newSize += 2;
+            newSize += 2
             if (contentRef.current) {
-              contentRef.current.style.fontSize = `${newSize}px`;
-              const { top, bottom } = contentRef.current.getBoundingClientRect();
-              const newContentHeight = bottom - top;
+              contentRef.current.style.fontSize = `${newSize}px`
+              const { top, bottom } = contentRef.current.getBoundingClientRect()
+              const newContentHeight = bottom - top
 
               if (newContentHeight > availableSpace) {
-                contentRef.current.style.fontSize = `${newSize - 2}px`;
-                adjusted = true;
-                newSize -= 2;
-                break;
+                contentRef.current.style.fontSize = `${newSize - 2}px`
+                adjusted = true
+                newSize -= 2
+                break
               }
             } else {
-              break;
+              break
             }
           }
 
           if (!adjusted) {
-            return newSize;
+            return newSize
           }
 
           return prevFontSize
@@ -77,14 +77,13 @@ export const Card = (props: CardProps) => {
     }
   }
 
+  const handleSaveContent = (values: CardModelData) => {
+    props.onUpdateCard && props.onUpdateCard(values)
+    handleSetEditingOff()
+    adjustFontSize()
+  }
+
   useEffect(() => {
-    let initialRender = true
-
-    if (initialRender) {
-      initialRender = false
-      return
-    }
-
     adjustFontSize()
   }, [])
 
@@ -92,21 +91,15 @@ export const Card = (props: CardProps) => {
     adjustFontSize()
   }, [props.content])
 
-  const handleSaveContent = (values: CardModelData) => {
-    props.onUpdateCard && props.onUpdateCard(values)
-    handleSetEditingOff()
-    adjustFontSize()
-  }
-
   return (
     <div
-      data-testid='card'
+      data-testid="card"
       data-cy={`card-${props.id}`}
       className={styles.card}
       onClick={handleSetEditingOn}
       ref={cardRef}
     >
-      <p ref={dateRef} className={styles.date} data-testid='card-date'>
+      <p ref={dateRef} className={styles.date} data-testid="card-date">
         {props.createdAt ? formatDate(props.createdAt) : 'Date'}
       </p>
       {!isEditing ? (

--- a/src/components/Card/CardAddNew.test.tsx
+++ b/src/components/Card/CardAddNew.test.tsx
@@ -1,3 +1,25 @@
+import { vi } from 'vitest'
+import { render, fireEvent } from '@testing-library/react';
+import { CardAddNew } from './CardAddNew';
+
 describe('CardAddNew component unit tests', () => {
-  // TODO: Add unit tests
+  it('renders button with correct text', () => {
+    const onAddCardMock = vi.fn();
+    const { getByText } = render(<CardAddNew onAddCard={onAddCardMock} />);
+    expect(getByText('Add new card')).toBeInTheDocument();
+  });
+
+  it('calls onAddCard function when button is clicked and not disabled', () => {
+    const onAddCardMock = vi.fn();
+    const { getByText } = render(<CardAddNew onAddCard={onAddCardMock} />);
+    fireEvent.click(getByText('Add new card'));
+    expect(onAddCardMock).toHaveBeenCalled();
+  });
+
+  it('does not call onAddCard function when button is clicked and disabled', () => {
+    const onAddCardMock = vi.fn();
+    const { getByText } = render(<CardAddNew onAddCard={onAddCardMock} disabled />);
+    fireEvent.click(getByText('Add new card'));
+    expect(onAddCardMock).not.toHaveBeenCalled();
+  });
 })

--- a/src/components/Card/card-elements/CardContentForm.tsx
+++ b/src/components/Card/card-elements/CardContentForm.tsx
@@ -24,7 +24,7 @@ export const CardContentForm = (props: CardContentFormProps) => {
   }
 
   return (
-    <form className={styles.form} onSubmit={handleSubmit}>
+    <form className={styles.form} onSubmit={handleSubmit} data-testid='card-edit-form'>
       <textarea
         className={styles.textarea}
         autoFocus


### PR DESCRIPTION
Applied logic for shrinking text's font-size by 2px when card is full of content. Starting font-size is 16px and minimal is 4px. Card finds a maximum size of text it can embody on first render and on form change - both for increasing and decreasing content inside. Also added tests for all crucial components.